### PR TITLE
Fix CSS module typings

### DIFF
--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -2,3 +2,8 @@ declare module '*.svg' {
   const content: string;
   export default content;
 }
+
+declare module '*.module.css' {
+  const classes: { [key: string]: string };
+  export default classes;
+}


### PR DESCRIPTION
## Summary
- add missing typings for `.module.css` files

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b5dc3fec832d9694269d9ad574b4