### PR TITLE
Add expense context reducer and provider

### DIFF
--- a/src/context/ExpenseContext.tsx
+++ b/src/context/ExpenseContext.tsx
@@ -1,20 +1,59 @@
 import React, { createContext, useReducer, ReactNode } from 'react';
-import { Expense } from '../models/expense';
+import { Expense, ExpenseFilterState } from '../models/expense';
 
-type State = {
+export type State = {
   expenses: Expense[];
+  filter: ExpenseFilterState;
 };
 
-type Action = { type: 'ADD_EXPENSE'; payload: Expense };
+export type Action =
+  | { type: 'ADD_EXPENSE'; payload: Expense }
+  | { type: 'EDIT_EXPENSE'; payload: Expense }
+  | { type: 'DELETE_EXPENSE'; payload: number }
+  | { type: 'SET_FILTER_CATEGORY'; payload?: number }
+  | {
+      type: 'SET_FILTER_DATE_RANGE';
+      payload: { startDate?: Date; endDate?: Date };
+    }
+  | { type: 'LOAD_EXPENSES'; payload: Expense[] };
 
-const initialState: State = {
+export const initialState: State = {
   expenses: [],
+  filter: {},
 };
 
-function reducer(state: State, action: Action): State {
+export function reducer(state: State, action: Action): State {
   switch (action.type) {
     case 'ADD_EXPENSE':
       return { ...state, expenses: [...state.expenses, action.payload] };
+    case 'EDIT_EXPENSE':
+      return {
+        ...state,
+        expenses: state.expenses.map((exp) =>
+          exp.id === action.payload.id ? action.payload : exp
+        ),
+      };
+    case 'DELETE_EXPENSE':
+      return {
+        ...state,
+        expenses: state.expenses.filter((exp) => exp.id !== action.payload),
+      };
+    case 'SET_FILTER_CATEGORY':
+      return {
+        ...state,
+        filter: { ...state.filter, categoryId: action.payload },
+      };
+    case 'SET_FILTER_DATE_RANGE':
+      return {
+        ...state,
+        filter: {
+          ...state.filter,
+          startDate: action.payload.startDate,
+          endDate: action.payload.endDate,
+        },
+      };
+    case 'LOAD_EXPENSES':
+      return { ...state, expenses: action.payload };
     default:
       return state;
   }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './styles/global.css';
 import App from './App';
+import { ExpenseProvider } from './context';
 import reportWebVitals from './reportWebVitals';
 
 const container = document.getElementById('root');
@@ -13,7 +14,9 @@ if (!container) {
 const root = ReactDOM.createRoot(container);
 root.render(
   <React.StrictMode>
-    <App />
+    <ExpenseProvider>
+      <App />
+    </ExpenseProvider>
   </React.StrictMode>
 );
 


### PR DESCRIPTION
## Summary
- extend `ExpenseContext` with actions and filter state
- wrap `App` with `ExpenseProvider` in `index.tsx`

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b8c45964832d8b47f475cd2d35f9