### PR TITLE
Fix hooks import path and typing

### DIFF
--- a/src/components/ExpenseFilters/ExpenseFilters.tsx
+++ b/src/components/ExpenseFilters/ExpenseFilters.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styles from './ExpenseFilters.module.css';
 import { useExpenses } from '../../hooks';
+import { Expense } from '../../models/expense';
 
 // Format a Date object into YYYY-MM-DD for date inputs
 const formatInputDate = (date?: Date) =>
@@ -15,7 +16,7 @@ const ExpenseFilters: React.FC = () => {
   // Collect unique categories from expenses
   const categories = React.useMemo(() => {
     const map = new Map<number, string>();
-    expenses.forEach((exp) => {
+    expenses.forEach((exp: Expense) => {
       map.set(exp.category.id, exp.category.name);
     });
     return Array.from(map.entries()).map(([id, name]) => ({ id, name }));

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from './useExpenses';
+export * from './useLocalStorage';


### PR DESCRIPTION
## Summary
- export hooks in new src/hooks/index.ts
- type expenses mapping in ExpenseFilters

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846bd625f64832d84736c1b08d071ae