### PR TITLE
Persist expenses to localStorage

### DIFF
--- a/src/context/ExpenseContext.tsx
+++ b/src/context/ExpenseContext.tsx
@@ -1,4 +1,9 @@
-import React, { createContext, useReducer, ReactNode } from 'react';
+import React, {
+  createContext,
+  useReducer,
+  ReactNode,
+  useEffect,
+} from 'react';
 import { Expense, ExpenseFilterState } from '../models/expense';
 
 export type State = {
@@ -66,6 +71,31 @@ export const ExpenseContext = createContext<{
 
 export const ExpenseProvider = ({ children }: { children: ReactNode }) => {
   const [state, dispatch] = useReducer(reducer, initialState);
+
+  // Load stored expenses on initial mount
+  useEffect(() => {
+    try {
+      const item = window.localStorage.getItem('expenses');
+      if (item) {
+        const expenses: Expense[] = JSON.parse(item, (key, value) => {
+          return key === 'date' ? new Date(value) : value;
+        });
+        dispatch({ type: 'LOAD_EXPENSES', payload: expenses });
+      }
+    } catch {
+      // ignore read errors
+    }
+  }, []);
+
+  // Persist expenses whenever they change
+  useEffect(() => {
+    try {
+      window.localStorage.setItem('expenses', JSON.stringify(state.expenses));
+    } catch {
+      // ignore write errors
+    }
+  }, [state.expenses]);
+
   return (
     <ExpenseContext.Provider value={{ state, dispatch }}>
       {children}


### PR DESCRIPTION
## Summary
- store expenses in localStorage and load them on app startup

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d3cbfe18832d9d57dd6c3d05ae0d