### PR TITLE
Improve date handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "react-dom": "^19.1.0",
     "react-scripts": "5.0.1",
     "typescript": "^5.8.3",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "date-fns": "^3.6.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/components/ExpenseChart/ExpenseChart.tsx
+++ b/src/components/ExpenseChart/ExpenseChart.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useExpenses } from '../../hooks';
 import styles from './ExpenseChart.module.css';
+import { isBefore, isAfter } from 'date-fns';
 
 // Chart types supported
 type ChartType = 'category' | 'time';
@@ -30,10 +31,10 @@ const ExpenseChart: React.FC = () => {
       if (filter.categoryId && exp.category.id !== filter.categoryId) {
         return false;
       }
-      if (filter.startDate && exp.date < filter.startDate) {
+      if (filter.startDate && isBefore(exp.date, filter.startDate)) {
         return false;
       }
-      if (filter.endDate && exp.date > filter.endDate) {
+      if (filter.endDate && isAfter(exp.date, filter.endDate)) {
         return false;
       }
       if (filter.text && !exp.description.toLowerCase().includes(filter.text.toLowerCase())) {

--- a/src/components/ExpenseFilters/ExpenseFilters.tsx
+++ b/src/components/ExpenseFilters/ExpenseFilters.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import styles from './ExpenseFilters.module.css';
 import { useExpenses } from '../../hooks';
 import { Expense } from '../../models/expense';
+import { parseDate, formatDate } from '../../utils/dateUtils';
 
-// Format a Date object into YYYY-MM-DD for date inputs
-const formatInputDate = (date?: Date) =>
-  date ? date.toISOString().split('T')[0] : '';
+// Format date for display in the inputs
+const formatInputDate = (date?: Date) => (date ? formatDate(date) : '');
 
 const ExpenseFilters: React.FC = () => {
   const {
@@ -33,7 +33,7 @@ const ExpenseFilters: React.FC = () => {
   const handleStartDateChange = (
     e: React.ChangeEvent<HTMLInputElement>,
   ) => {
-    const startDate = e.target.value ? new Date(e.target.value) : undefined;
+    const startDate = e.target.value ? parseDate(e.target.value) : undefined;
     dispatch({
       type: 'SET_FILTER_DATE_RANGE',
       payload: { startDate, endDate: filter.endDate },
@@ -43,7 +43,7 @@ const ExpenseFilters: React.FC = () => {
   const handleEndDateChange = (
     e: React.ChangeEvent<HTMLInputElement>,
   ) => {
-    const endDate = e.target.value ? new Date(e.target.value) : undefined;
+    const endDate = e.target.value ? parseDate(e.target.value) : undefined;
     dispatch({
       type: 'SET_FILTER_DATE_RANGE',
       payload: { startDate: filter.startDate, endDate },
@@ -64,12 +64,14 @@ const ExpenseFilters: React.FC = () => {
         ))}
       </select>
       <input
-        type="date"
+        type="text"
+        placeholder="dd/mm/yyyy"
         value={formatInputDate(filter.startDate)}
         onChange={handleStartDateChange}
       />
       <input
-        type="date"
+        type="text"
+        placeholder="dd/mm/yyyy"
         value={formatInputDate(filter.endDate)}
         onChange={handleEndDateChange}
       />

--- a/src/components/ExpenseForm/ExpenseForm.tsx
+++ b/src/components/ExpenseForm/ExpenseForm.tsx
@@ -4,6 +4,7 @@ import { Expense } from '../../models/expense';
 import { useExpenses } from '../../hooks';
 import Button from '../common/Button';
 import Input from '../common/Input';
+import { parseDate, formatDate } from '../../utils/dateUtils';
 
 interface ExpenseFormProps {
   expense?: Expense;
@@ -23,7 +24,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onCancel }) => {
     expense?.category.name ?? '',
   );
   const [date, setDate] = React.useState(
-    expense ? expense.date.toISOString().split('T')[0] : '',
+    expense ? formatDate(expense.date) : '',
   );
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -33,7 +34,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onCancel }) => {
       description,
       amount: parseFloat(amount) || 0,
       category: expense?.category ?? { id: Date.now(), name: category },
-      date: date ? new Date(date) : new Date(),
+      date: date ? parseDate(date) : new Date(),
     };
     dispatch({ type: expense ? 'EDIT_EXPENSE' : 'ADD_EXPENSE', payload: updated });
     onCancel?.();
@@ -58,7 +59,8 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onCancel }) => {
         onChange={(e) => setCategory(e.target.value)}
       />
       <Input
-        type="date"
+        type="text"
+        placeholder="dd/mm/yyyy"
         value={date}
         onChange={(e) => setDate(e.target.value)}
       />

--- a/src/components/ExpenseList/ExpenseItem.tsx
+++ b/src/components/ExpenseList/ExpenseItem.tsx
@@ -3,6 +3,7 @@ import { Expense } from '../../models/expense';
 import Button from '../common/Button';
 import styles from './ExpenseItem.module.css';
 import { formatCurrency } from '../../utils/numberUtils';
+import { formatDate } from '../../utils/dateUtils';
 
 interface Props {
   expense: Expense;
@@ -16,7 +17,7 @@ const ExpenseItem: React.FC<Props> = ({ expense, onEdit, onDelete }) => {
       <span>{expense.description}</span>
       <span>{formatCurrency(expense.amount)}</span>
       <span>{expense.category.name}</span>
-      <span>{expense.date.toLocaleDateString()}</span>
+      <span>{formatDate(expense.date)}</span>
       <div className={styles.buttons}>
         <Button onClick={onEdit}>Edit</Button>
         <Button onClick={onDelete}>Delete</Button>

--- a/src/components/ExpenseList/ExpenseList.tsx
+++ b/src/components/ExpenseList/ExpenseList.tsx
@@ -4,6 +4,7 @@ import ExpenseForm from '../ExpenseForm/ExpenseForm';
 import styles from './ExpenseList.module.css';
 import { useExpenses } from '../../hooks';
 import { Expense } from '../../models/expense';
+import { isBefore, isAfter } from 'date-fns';
 
 const ExpenseList: React.FC = () => {
   const {
@@ -18,10 +19,10 @@ const ExpenseList: React.FC = () => {
       if (filter.categoryId && exp.category.id !== filter.categoryId) {
         return false;
       }
-      if (filter.startDate && exp.date < filter.startDate) {
+      if (filter.startDate && isBefore(exp.date, filter.startDate)) {
         return false;
       }
-      if (filter.endDate && exp.date > filter.endDate) {
+      if (filter.endDate && isAfter(exp.date, filter.endDate)) {
         return false;
       }
       if (filter.text && !exp.description.toLowerCase().includes(filter.text.toLowerCase())) {

--- a/src/components/ExpenseSummary/ExpenseSummary.tsx
+++ b/src/components/ExpenseSummary/ExpenseSummary.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useExpenses } from '../../hooks';
 import styles from './ExpenseSummary.module.css';
 import { formatCurrency } from '../../utils/numberUtils';
+import { isBefore, isAfter } from 'date-fns';
 
 const ExpenseSummary: React.FC = () => {
   const {
@@ -13,10 +14,10 @@ const ExpenseSummary: React.FC = () => {
       if (filter.categoryId && exp.category.id !== filter.categoryId) {
         return false;
       }
-      if (filter.startDate && exp.date < filter.startDate) {
+      if (filter.startDate && isBefore(exp.date, filter.startDate)) {
         return false;
       }
-      if (filter.endDate && exp.date > filter.endDate) {
+      if (filter.endDate && isAfter(exp.date, filter.endDate)) {
         return false;
       }
       if (filter.text && !exp.description.toLowerCase().includes(filter.text.toLowerCase())) {

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,1 +1,11 @@
-export const formatDate = (date: string) => new Date(date).toLocaleDateString();
+import { parse, format } from 'date-fns';
+
+// Parse a date string in dd/MM/yyyy format
+export const parseDate = (value: string): Date =>
+  parse(value, 'dd/MM/yyyy', new Date());
+
+// Format a Date object as dd/MM/yyyy for display
+export const formatDate = (date: Date): string => format(date, 'dd/MM/yyyy');
+
+// Format a Date object as ISO yyyy-MM-dd for storage
+export const toISODate = (date: Date): string => format(date, 'yyyy-MM-dd');


### PR DESCRIPTION
## Summary
- add date-fns dependency
- implement date utilities using date-fns
- parse and format user input dates as dd/mm/yyyy
- compare dates using date-fns helpers

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e7db5b88832d977bf9c18ab0abe7