### PR TITLE
Remove date-fns dependency with custom utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "react-dom": "^19.1.0",
     "react-scripts": "5.0.1",
     "typescript": "^5.8.3",
-    "web-vitals": "^2.1.4",
-    "date-fns": "^3.6.0"
+    "web-vitals": "^2.1.4"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/components/ExpenseChart/ExpenseChart.tsx
+++ b/src/components/ExpenseChart/ExpenseChart.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useExpenses } from '../../hooks';
 import styles from './ExpenseChart.module.css';
-import { isBefore, isAfter } from 'date-fns';
+import { isBefore, isAfter } from '../../utils/dateUtils';
 
 // Chart types supported
 type ChartType = 'category' | 'time';

--- a/src/components/ExpenseList/ExpenseList.tsx
+++ b/src/components/ExpenseList/ExpenseList.tsx
@@ -4,7 +4,7 @@ import ExpenseForm from '../ExpenseForm/ExpenseForm';
 import styles from './ExpenseList.module.css';
 import { useExpenses } from '../../hooks';
 import { Expense } from '../../models/expense';
-import { isBefore, isAfter } from 'date-fns';
+import { isBefore, isAfter } from '../../utils/dateUtils';
 
 const ExpenseList: React.FC = () => {
   const {

--- a/src/components/ExpenseSummary/ExpenseSummary.tsx
+++ b/src/components/ExpenseSummary/ExpenseSummary.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useExpenses } from '../../hooks';
 import styles from './ExpenseSummary.module.css';
 import { formatCurrency } from '../../utils/numberUtils';
-import { isBefore, isAfter } from 'date-fns';
+import { isBefore, isAfter } from '../../utils/dateUtils';
 
 const ExpenseSummary: React.FC = () => {
   const {

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,11 +1,28 @@
-import { parse, format } from 'date-fns';
+// Compare two dates
+export const isBefore = (a: Date, b: Date): boolean => a.getTime() < b.getTime();
+export const isAfter = (a: Date, b: Date): boolean => a.getTime() > b.getTime();
 
 // Parse a date string in dd/MM/yyyy format
-export const parseDate = (value: string): Date =>
-  parse(value, 'dd/MM/yyyy', new Date());
+export const parseDate = (value: string): Date => {
+  const [dayStr, monthStr, yearStr] = value.split('/');
+  const day = Number(dayStr);
+  const month = Number(monthStr) - 1;
+  const year = Number(yearStr);
+  return new Date(year, month, day);
+};
 
 // Format a Date object as dd/MM/yyyy for display
-export const formatDate = (date: Date): string => format(date, 'dd/MM/yyyy');
+export const formatDate = (date: Date): string => {
+  const day = String(date.getDate()).padStart(2, '0');
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const year = date.getFullYear();
+  return `${day}/${month}/${year}`;
+};
 
 // Format a Date object as ISO yyyy-MM-dd for storage
-export const toISODate = (date: Date): string => format(date, 'yyyy-MM-dd');
+export const toISODate = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};


### PR DESCRIPTION
## Summary
- replace `date-fns` with custom date utilities
- update imports to use new utilities
- remove `date-fns` from package.json

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68481aaeff28832daff41be6b2d638b5