### PR TITLE
Add predefined categories dropdown

### DIFF
--- a/src/components/ExpenseFilters/ExpenseFilters.tsx
+++ b/src/components/ExpenseFilters/ExpenseFilters.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styles from './ExpenseFilters.module.css';
 import { useExpenses } from '../../hooks';
-import { Expense } from '../../models/expense';
+import { CATEGORIES } from '../../constants';
 
 // Format a Date object into YYYY-MM-DD for date inputs
 const formatInputDate = (date?: Date) =>
@@ -9,18 +9,10 @@ const formatInputDate = (date?: Date) =>
 
 const ExpenseFilters: React.FC = () => {
   const {
-    state: { expenses, filter },
+    state: { filter },
     dispatch,
   } = useExpenses();
 
-  // Collect unique categories from expenses
-  const categories = React.useMemo(() => {
-    const map = new Map<number, string>();
-    expenses.forEach((exp: Expense) => {
-      map.set(exp.category.id, exp.category.name);
-    });
-    return Array.from(map.entries()).map(([id, name]) => ({ id, name }));
-  }, [expenses]);
 
   const handleCategoryChange = (
     e: React.ChangeEvent<HTMLSelectElement>,
@@ -57,7 +49,7 @@ const ExpenseFilters: React.FC = () => {
         onChange={handleCategoryChange}
       >
         <option value="">All</option>
-        {categories.map((cat) => (
+        {CATEGORIES.map((cat) => (
           <option key={cat.id} value={cat.id}>
             {cat.name}
           </option>

--- a/src/components/ExpenseForm/ExpenseForm.tsx
+++ b/src/components/ExpenseForm/ExpenseForm.tsx
@@ -4,6 +4,7 @@ import { Expense } from '../../models/expense';
 import { useExpenses } from '../../hooks';
 import Button from '../common/Button';
 import Input from '../common/Input';
+import { CATEGORIES } from '../../constants';
 
 interface ExpenseFormProps {
   expense?: Expense;
@@ -19,8 +20,10 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onCancel }) => {
   const [amount, setAmount] = React.useState(
     expense ? String(expense.amount) : '',
   );
-  const [category, setCategory] = React.useState(
-    expense?.category.name ?? '',
+  const [categoryId, setCategoryId] = React.useState<number>(
+    expense && CATEGORIES.some((c) => c.id === expense.category.id)
+      ? expense.category.id
+      : CATEGORIES[0].id,
   );
   const [date, setDate] = React.useState(
     expense ? expense.date.toISOString().split('T')[0] : '',
@@ -28,11 +31,13 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onCancel }) => {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    const selectedCategory =
+      CATEGORIES.find((c) => c.id === categoryId) || CATEGORIES[CATEGORIES.length - 1];
     const updated: Expense = {
       id: expense ? expense.id : Date.now(),
       description,
       amount: parseFloat(amount) || 0,
-      category: expense?.category ?? { id: Date.now(), name: category },
+      category: { ...selectedCategory },
       date: date ? new Date(date) : new Date(),
     };
     dispatch({ type: expense ? 'EDIT_EXPENSE' : 'ADD_EXPENSE', payload: updated });
@@ -52,11 +57,13 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({ expense, onCancel }) => {
         value={amount}
         onChange={(e) => setAmount(e.target.value)}
       />
-      <Input
-        placeholder="Category"
-        value={category}
-        onChange={(e) => setCategory(e.target.value)}
-      />
+      <select value={categoryId} onChange={(e) => setCategoryId(Number(e.target.value))}>
+        {CATEGORIES.map((cat) => (
+          <option key={cat.id} value={cat.id}>
+            {cat.name}
+          </option>
+        ))}
+      </select>
       <Input
         type="date"
         value={date}

--- a/src/constants/categories.ts
+++ b/src/constants/categories.ts
@@ -1,0 +1,10 @@
+import { Category } from '../models/expense';
+
+export const CATEGORIES: Category[] = [
+  { id: 1, name: 'Food' },
+  { id: 2, name: 'Rent' },
+  { id: 3, name: 'Transport' },
+  { id: 4, name: 'Utilities' },
+  { id: 5, name: 'Entertainment' },
+  { id: 6, name: 'Others' },
+];

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './categories';


### PR DESCRIPTION
## Summary
- add a constants module with predefined expense categories
- change `ExpenseForm` to use a select box instead of free text
- update `ExpenseFilters` to show the same predefined categories

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68481f9cf938832db86a4386871f6809