### PR TITLE
Implement shared filtering and date range validation

### DIFF
--- a/src/components/ExpenseChart/ExpenseChart.tsx
+++ b/src/components/ExpenseChart/ExpenseChart.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useExpenses } from '../../hooks';
 import styles from './ExpenseChart.module.css';
+import { filterExpenses } from '../../utils/filterExpenses';
 
 // Chart types supported
 type ChartType = 'category' | 'time';
@@ -25,23 +26,10 @@ const ExpenseChart: React.FC = () => {
   const [chartType, setChartType] = React.useState<ChartType>('category');
 
   // Apply same filtering logic as other components
-  const filteredExpenses = React.useMemo(() => {
-    return expenses.filter((exp) => {
-      if (filter.categoryId && exp.category.id !== filter.categoryId) {
-        return false;
-      }
-      if (filter.startDate && exp.date < filter.startDate) {
-        return false;
-      }
-      if (filter.endDate && exp.date > filter.endDate) {
-        return false;
-      }
-      if (filter.text && !exp.description.toLowerCase().includes(filter.text.toLowerCase())) {
-        return false;
-      }
-      return true;
-    });
-  }, [expenses, filter]);
+  const filteredExpenses = React.useMemo(
+    () => filterExpenses(expenses, filter),
+    [expenses, filter],
+  );
 
   const categoryTotals = React.useMemo(() => {
     const map = new Map<number, { name: string; total: number }>();

--- a/src/components/ExpenseFilters/ExpenseFilters.tsx
+++ b/src/components/ExpenseFilters/ExpenseFilters.tsx
@@ -26,9 +26,13 @@ const ExpenseFilters: React.FC = () => {
     e: React.ChangeEvent<HTMLInputElement>,
   ) => {
     const startDate = e.target.value ? new Date(e.target.value) : undefined;
+    let endDate = filter.endDate;
+    if (startDate && endDate && startDate > endDate) {
+      endDate = startDate;
+    }
     dispatch({
       type: 'SET_FILTER_DATE_RANGE',
-      payload: { startDate, endDate: filter.endDate },
+      payload: { startDate, endDate },
     });
   };
 
@@ -36,9 +40,13 @@ const ExpenseFilters: React.FC = () => {
     e: React.ChangeEvent<HTMLInputElement>,
   ) => {
     const endDate = e.target.value ? new Date(e.target.value) : undefined;
+    let startDate = filter.startDate;
+    if (startDate && endDate && endDate < startDate) {
+      startDate = endDate;
+    }
     dispatch({
       type: 'SET_FILTER_DATE_RANGE',
-      payload: { startDate: filter.startDate, endDate },
+      payload: { startDate, endDate },
     });
   };
 

--- a/src/components/ExpenseList/ExpenseList.tsx
+++ b/src/components/ExpenseList/ExpenseList.tsx
@@ -4,6 +4,7 @@ import ExpenseForm from '../ExpenseForm/ExpenseForm';
 import styles from './ExpenseList.module.css';
 import { useExpenses } from '../../hooks';
 import { Expense } from '../../models/expense';
+import { filterExpenses } from '../../utils/filterExpenses';
 
 const ExpenseList: React.FC = () => {
   const {
@@ -13,23 +14,10 @@ const ExpenseList: React.FC = () => {
 
   const [editingExpense, setEditingExpense] = React.useState<Expense | null>(null);
 
-  const filteredExpenses = React.useMemo(() => {
-    return expenses.filter((exp) => {
-      if (filter.categoryId && exp.category.id !== filter.categoryId) {
-        return false;
-      }
-      if (filter.startDate && exp.date < filter.startDate) {
-        return false;
-      }
-      if (filter.endDate && exp.date > filter.endDate) {
-        return false;
-      }
-      if (filter.text && !exp.description.toLowerCase().includes(filter.text.toLowerCase())) {
-        return false;
-      }
-      return true;
-    });
-  }, [expenses, filter]);
+  const filteredExpenses = React.useMemo(
+    () => filterExpenses(expenses, filter),
+    [expenses, filter],
+  );
 
   const handleDelete = (id: number) => {
     dispatch({ type: 'DELETE_EXPENSE', payload: id });

--- a/src/components/ExpenseSummary/ExpenseSummary.tsx
+++ b/src/components/ExpenseSummary/ExpenseSummary.tsx
@@ -2,29 +2,17 @@ import React from 'react';
 import { useExpenses } from '../../hooks';
 import styles from './ExpenseSummary.module.css';
 import { formatCurrency } from '../../utils/numberUtils';
+import { filterExpenses } from '../../utils/filterExpenses';
 
 const ExpenseSummary: React.FC = () => {
   const {
     state: { expenses, filter },
   } = useExpenses();
 
-  const filteredExpenses = React.useMemo(() => {
-    return expenses.filter((exp) => {
-      if (filter.categoryId && exp.category.id !== filter.categoryId) {
-        return false;
-      }
-      if (filter.startDate && exp.date < filter.startDate) {
-        return false;
-      }
-      if (filter.endDate && exp.date > filter.endDate) {
-        return false;
-      }
-      if (filter.text && !exp.description.toLowerCase().includes(filter.text.toLowerCase())) {
-        return false;
-      }
-      return true;
-    });
-  }, [expenses, filter]);
+  const filteredExpenses = React.useMemo(
+    () => filterExpenses(expenses, filter),
+    [expenses, filter],
+  );
 
   const total = React.useMemo(
     () => filteredExpenses.reduce((sum, exp) => sum + exp.amount, 0),

--- a/src/utils/filterExpenses.ts
+++ b/src/utils/filterExpenses.ts
@@ -1,0 +1,24 @@
+import { Expense, ExpenseFilterState } from '../models/expense';
+
+export const filterExpenses = (
+  expenses: Expense[],
+  filter: ExpenseFilterState,
+): Expense[] => {
+  return expenses.filter((exp) => {
+    if (filter.categoryId && exp.category.id !== filter.categoryId) {
+      return false;
+    }
+    if (filter.startDate && exp.date < filter.startDate) {
+      return false;
+    }
+    if (filter.endDate && exp.date > filter.endDate) {
+      return false;
+    }
+    if (filter.text && !exp.description.toLowerCase().includes(filter.text.toLowerCase())) {
+      return false;
+    }
+    return true;
+  });
+};
+
+export default filterExpenses;


### PR DESCRIPTION
## Summary
- ensure expense list, summary, and chart use the same filtering logic
- validate date range inputs so start date can't exceed end date

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684823da82fc832d8f2378ece304bdf6