### PR TITLE
Add Recharts-based ExpenseChart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Getting Started with Create React App
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+Before running the project, install dependencies with `npm install`. The app uses Recharts for data visualizations.
+
 
 ## Available Scripts
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-scripts": "5.0.1",
+    "recharts": "^2.8.0",
     "typescript": "^5.8.3",
     "web-vitals": "^2.1.4"
   },

--- a/src/components/ExpenseChart/ExpenseChart.tsx
+++ b/src/components/ExpenseChart/ExpenseChart.tsx
@@ -33,13 +33,13 @@ const ExpenseChart: React.FC = () => {
   );
 
   const categoryTotals = React.useMemo(() => {
-    const map = new Map<number, { name: string; value: number }>();
+    const map = new Map<number, { name: string; total: number }>();
     filteredExpenses.forEach((exp) => {
       const entry = map.get(exp.category.id);
       if (entry) {
-        entry.value += exp.amount;
+        entry.total += exp.amount;
       } else {
-        map.set(exp.category.id, { name: exp.category.name, value: exp.amount });
+        map.set(exp.category.id, { name: exp.category.name, total: exp.amount });
       }
     });
     return Array.from(map.values());
@@ -67,7 +67,7 @@ const ExpenseChart: React.FC = () => {
       {chartType === 'category' ? (
         <ResponsiveContainer width="100%" height={250}>
           <PieChart>
-            <Pie data={categoryTotals} dataKey="value" nameKey="name" cx="50%" cy="50%" outerRadius={80}>
+            <Pie data={categoryTotals} dataKey="total" nameKey="name" cx="50%" cy="50%" outerRadius={80}>
               {categoryTotals.map((entry, index) => (
                 <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
               ))}


### PR DESCRIPTION
## Summary
- use Recharts for ExpenseChart visualizations
- track new recharts dependency in package.json

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848259def94832d84f9a5da3813fe39