### PR TITLE
Add comprehensive tests

### DIFF
--- a/src/components/ExpenseChart/ExpenseChart.test.tsx
+++ b/src/components/ExpenseChart/ExpenseChart.test.tsx
@@ -1,0 +1,18 @@
+import { fireEvent, screen } from '@testing-library/react';
+import ExpenseChart from './ExpenseChart';
+import { renderWithContext } from '../../test-utils';
+import { Expense } from '../../models/expense';
+
+const expenses: Expense[] = [
+  { id: 1, description: 'Coffee', amount: 3, category: { id: 1, name: 'Food' }, date: new Date('2024-01-01') },
+  { id: 2, description: 'Rent', amount: 10, category: { id: 2, name: 'Rent' }, date: new Date('2024-01-02') },
+];
+
+test('renders chart with select', () => {
+  renderWithContext(<ExpenseChart />, { state: { expenses, filter: {} } });
+  const select = screen.getByRole('combobox');
+  expect(select).toBeInTheDocument();
+  fireEvent.change(select, { target: { value: 'time' } });
+  expect((select as HTMLSelectElement).value).toBe('time');
+  expect(document.querySelector('.recharts-responsive-container')).toBeInTheDocument();
+});

--- a/src/components/ExpenseFilters/ExpenseFilters.test.tsx
+++ b/src/components/ExpenseFilters/ExpenseFilters.test.tsx
@@ -1,0 +1,18 @@
+import { fireEvent, screen } from '@testing-library/react';
+import ExpenseFilters from './ExpenseFilters';
+import { renderWithContext } from '../../test-utils';
+
+it('dispatches category filter', () => {
+  const { dispatch } = renderWithContext(<ExpenseFilters />, { state: { expenses: [], filter: {} } });
+  fireEvent.change(screen.getByRole('combobox'), { target: { value: '1' } });
+  expect(dispatch).toHaveBeenCalledWith({ type: 'SET_FILTER_CATEGORY', payload: 1 });
+});
+
+it('dispatches date range filter', () => {
+  const { container, dispatch } = renderWithContext(<ExpenseFilters />, { state: { expenses: [], filter: {} } });
+  const inputs = container.querySelectorAll('input');
+  fireEvent.change(inputs[0], { target: { value: '2024-01-01' } });
+  expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ type: 'SET_FILTER_DATE_RANGE' }));
+  fireEvent.change(inputs[1], { target: { value: '2024-01-02' } });
+  expect(dispatch).toHaveBeenLastCalledWith(expect.objectContaining({ type: 'SET_FILTER_DATE_RANGE' }));
+});

--- a/src/components/ExpenseForm/ExpenseForm.test.tsx
+++ b/src/components/ExpenseForm/ExpenseForm.test.tsx
@@ -1,0 +1,33 @@
+import { fireEvent, screen } from '@testing-library/react';
+import ExpenseForm from './ExpenseForm';
+import { renderWithContext } from '../../test-utils';
+
+
+it('renders form inputs', () => {
+  renderWithContext(<ExpenseForm />);
+  expect(screen.getByPlaceholderText(/description/i)).toBeInTheDocument();
+  expect(screen.getByPlaceholderText(/amount/i)).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument();
+});
+
+it('updates state on input change', () => {
+  renderWithContext(<ExpenseForm />);
+  const desc = screen.getByPlaceholderText(/description/i) as HTMLInputElement;
+  fireEvent.change(desc, { target: { value: 'Coffee' } });
+  expect(desc.value).toBe('Coffee');
+});
+
+it('shows validation errors', () => {
+  renderWithContext(<ExpenseForm />);
+  fireEvent.click(screen.getByRole('button', { name: /save/i }));
+  expect(screen.getByText(/please enter a description/i)).toBeInTheDocument();
+  expect(screen.getByText(/amount must be greater than 0/i)).toBeInTheDocument();
+});
+
+it('dispatches add action on submit', () => {
+  const { dispatch } = renderWithContext(<ExpenseForm />);
+  fireEvent.change(screen.getByPlaceholderText(/description/i), { target: { value: 'Coffee' } });
+  fireEvent.change(screen.getByPlaceholderText(/amount/i), { target: { value: '5' } });
+  fireEvent.click(screen.getByRole('button', { name: /save/i }));
+  expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ type: 'ADD_EXPENSE' }));
+});

--- a/src/components/ExpenseList/ExpenseList.test.tsx
+++ b/src/components/ExpenseList/ExpenseList.test.tsx
@@ -1,0 +1,39 @@
+import { fireEvent, screen } from '@testing-library/react';
+import ExpenseList from './ExpenseList';
+import { renderWithContext } from '../../test-utils';
+import { Expense } from '../../models/expense';
+
+const expenses: Expense[] = [
+  {
+    id: 1,
+    description: 'Coffee',
+    amount: 3,
+    category: { id: 1, name: 'Food' },
+    date: new Date('2024-01-01'),
+  },
+  {
+    id: 2,
+    description: 'Bus',
+    amount: 2,
+    category: { id: 3, name: 'Transport' },
+    date: new Date('2024-01-02'),
+  },
+];
+
+it('renders expense items', () => {
+  renderWithContext(<ExpenseList />, { state: { expenses, filter: {} } });
+  expect(screen.getByText('Coffee')).toBeInTheDocument();
+  expect(screen.getByText('Bus')).toBeInTheDocument();
+});
+
+it('allows deleting an expense', () => {
+  const { dispatch } = renderWithContext(<ExpenseList />, { state: { expenses, filter: {} } });
+  fireEvent.click(screen.getAllByText('Delete')[0]);
+  expect(dispatch).toHaveBeenCalledWith({ type: 'DELETE_EXPENSE', payload: 1 });
+});
+
+it('shows edit form when clicking edit', () => {
+  renderWithContext(<ExpenseList />, { state: { expenses, filter: {} } });
+  fireEvent.click(screen.getAllByText('Edit')[0]);
+  expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument();
+});

--- a/src/context/ExpenseContext.test.ts
+++ b/src/context/ExpenseContext.test.ts
@@ -1,0 +1,24 @@
+import { reducer, initialState, State } from './ExpenseContext';
+import { Expense } from '../models/expense';
+
+test('initial state', () => {
+  expect(initialState).toEqual({ expenses: [], filter: {} });
+});
+
+test('add, edit and delete expense actions', () => {
+  const exp: Expense = { id: 1, description: 'Coffee', amount: 3, category: { id: 1, name: 'Food' }, date: new Date('2024-01-01') };
+  let state: State = reducer(initialState, { type: 'ADD_EXPENSE', payload: exp });
+  expect(state.expenses).toHaveLength(1);
+  state = reducer(state, { type: 'EDIT_EXPENSE', payload: { ...exp, amount: 4 } });
+  expect(state.expenses[0].amount).toBe(4);
+  state = reducer(state, { type: 'DELETE_EXPENSE', payload: 1 });
+  expect(state.expenses).toHaveLength(0);
+});
+
+test('filter actions', () => {
+  let state: State = reducer(initialState, { type: 'SET_FILTER_CATEGORY', payload: 2 });
+  expect(state.filter.categoryId).toBe(2);
+  state = reducer(state, { type: 'SET_FILTER_DATE_RANGE', payload: { startDate: new Date('2024-01-01'), endDate: new Date('2024-01-02') } });
+  expect(state.filter.startDate).toBeInstanceOf(Date);
+  expect(state.filter.endDate).toBeInstanceOf(Date);
+});

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -1,0 +1,18 @@
+import React, { ReactElement } from 'react';
+import { render } from '@testing-library/react';
+import { ExpenseContext, State, Action, initialState } from './context/ExpenseContext';
+
+export function renderWithContext(
+  ui: ReactElement,
+  {
+    state = initialState,
+    dispatch = jest.fn<ReturnType<React.Dispatch<Action>>, Parameters<React.Dispatch<Action>>>()
+  } = {},
+) {
+  return {
+    dispatch,
+    ...render(
+      <ExpenseContext.Provider value={{ state, dispatch }}>{ui}</ExpenseContext.Provider>,
+    ),
+  };
+}

--- a/src/utils/filterExpenses.test.ts
+++ b/src/utils/filterExpenses.test.ts
@@ -1,0 +1,26 @@
+import { filterExpenses } from './filterExpenses';
+import { Expense } from '../models/expense';
+
+const expenses: Expense[] = [
+  { id: 1, description: 'Coffee', amount: 3, category: { id: 1, name: 'Food' }, date: new Date('2024-01-01') },
+  { id: 2, description: 'Rent', amount: 10, category: { id: 2, name: 'Rent' }, date: new Date('2024-01-05') },
+  { id: 3, description: 'Bus ticket', amount: 2, category: { id: 3, name: 'Transport' }, date: new Date('2024-01-10') },
+];
+
+test('filters by category', () => {
+  const result = filterExpenses(expenses, { categoryId: 2 });
+  expect(result).toHaveLength(1);
+  expect(result[0].description).toBe('Rent');
+});
+
+test('filters by date range', () => {
+  const result = filterExpenses(expenses, { startDate: new Date('2024-01-02'), endDate: new Date('2024-01-06') });
+  expect(result).toHaveLength(1);
+  expect(result[0].description).toBe('Rent');
+});
+
+test('filters by text search', () => {
+  const result = filterExpenses(expenses, { text: 'bus' });
+  expect(result).toHaveLength(1);
+  expect(result[0].description).toBe('Bus ticket');
+});


### PR DESCRIPTION
## Summary
- add utility `renderWithContext` for simpler testing
- cover `ExpenseForm`, `ExpenseList`, `ExpenseChart` and `ExpenseFilters`
- test `ExpenseContext` reducer
- test `filterExpenses` helper

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6849e0518808832d82da33477dc6b73f