### PR TITLE
Add integration tests for expenses

### DIFF
--- a/src/__tests__/integration/expense-flow.test.tsx
+++ b/src/__tests__/integration/expense-flow.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import App from "../../App";
+
+describe("Expense integration flow", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+  const addExpense = async (
+    desc: string,
+    amount: string,
+    category: string,
+    date: string,
+    expected: number,
+  ) => {
+    await userEvent.type(screen.getByPlaceholderText(/description/i), desc);
+    await userEvent.type(screen.getByPlaceholderText(/amount/i), amount);
+    await userEvent.selectOptions(screen.getAllByRole("combobox")[0], category);
+    const dateInputs = document.querySelectorAll('input[type="date"]');
+    const formDate = dateInputs[0] as HTMLInputElement;
+    await userEvent.clear(formDate);
+    await userEvent.type(formDate, date);
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+    await waitFor(() =>
+      expect(screen.getAllByText("Delete").length).toBe(expected),
+    );
+  };
+
+  test("adding expenses updates list and chart", async () => {
+    render(<App />);
+    await addExpense("Coffee", "3", "Food", "2024-01-01", 1);
+    expect(screen.getByText("Coffee")).toBeInTheDocument();
+    expect(
+      document.querySelector(".recharts-responsive-container"),
+    ).toBeInTheDocument();
+
+    await addExpense("Rent", "10", "Rent", "2024-01-15", 2);
+    expect(screen.getAllByText("Edit")).toHaveLength(2);
+  });
+
+  test("filters by category and date range", async () => {
+    render(<App />);
+    await addExpense("Coffee", "3", "Food", "2024-01-01", 1);
+    await addExpense("Rent", "10", "Rent", "2024-01-15", 2);
+    await addExpense("Bus", "2", "Transport", "2024-02-01", 3);
+
+    // category filter
+    await userEvent.selectOptions(screen.getAllByRole("combobox")[1], "2");
+    await waitFor(() => expect(screen.getAllByText("Delete").length).toBe(1));
+    expect(screen.queryByText("Coffee")).toBeNull();
+    expect(
+      document.querySelector(".recharts-responsive-container"),
+    ).toBeInTheDocument();
+
+    // date filter
+    const dateInputs = document.querySelectorAll('.filters input[type="date"]');
+    await userEvent.clear(dateInputs[0] as HTMLInputElement);
+    await userEvent.type(dateInputs[0] as HTMLInputElement, "2024-02-01");
+    await userEvent.clear(dateInputs[1] as HTMLInputElement);
+    await userEvent.type(dateInputs[1] as HTMLInputElement, "2024-02-28");
+    await userEvent.selectOptions(screen.getAllByRole("combobox")[1], "");
+    await waitFor(() => expect(screen.getAllByText("Delete").length).toBe(1));
+    expect(screen.getByText("Bus")).toBeInTheDocument();
+  });
+
+  test("shows error on invalid date range", async () => {
+    render(<App />);
+    const dateInputs = document.querySelectorAll('.filters input[type="date"]');
+    await userEvent.type(dateInputs[0] as HTMLInputElement, "2024-02-10");
+    await userEvent.type(dateInputs[1] as HTMLInputElement, "2024-02-01");
+    expect(screen.getByRole("alert")).toHaveTextContent(/invalid date range/i);
+  });
+});

--- a/src/components/ExpenseFilters/ExpenseFilters.module.css
+++ b/src/components/ExpenseFilters/ExpenseFilters.module.css
@@ -4,6 +4,11 @@
   margin: 1rem 0;
 }
 
+.error {
+  color: red;
+  font-size: 0.875rem;
+}
+
 @media (max-width: 480px) {
   .filters {
     flex-direction: column;

--- a/src/components/ExpenseFilters/ExpenseFilters.tsx
+++ b/src/components/ExpenseFilters/ExpenseFilters.tsx
@@ -1,61 +1,56 @@
-import React from 'react';
-import styles from './ExpenseFilters.module.css';
-import { useExpenses } from '../../hooks';
-import { CATEGORIES } from '../../constants';
+import React from "react";
+import styles from "./ExpenseFilters.module.css";
+import { useExpenses } from "../../hooks";
+import { CATEGORIES } from "../../constants";
 
 // Format a Date object into YYYY-MM-DD for date inputs
 const formatInputDate = (date?: Date) =>
-  date ? date.toISOString().split('T')[0] : '';
+  date ? date.toISOString().split("T")[0] : "";
 
 const ExpenseFilters: React.FC = () => {
   const {
     state: { filter },
     dispatch,
   } = useExpenses();
+  const [error, setError] = React.useState<string | null>(null);
 
-
-  const handleCategoryChange = (
-    e: React.ChangeEvent<HTMLSelectElement>,
-  ) => {
+  const handleCategoryChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const value = e.target.value;
     const categoryId = value ? Number(value) : undefined;
-    dispatch({ type: 'SET_FILTER_CATEGORY', payload: categoryId });
+    dispatch({ type: "SET_FILTER_CATEGORY", payload: categoryId });
   };
 
-  const handleStartDateChange = (
-    e: React.ChangeEvent<HTMLInputElement>,
-  ) => {
+  const handleStartDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const startDate = e.target.value ? new Date(e.target.value) : undefined;
-    let endDate = filter.endDate;
+    const endDate = filter.endDate;
     if (startDate && endDate && startDate > endDate) {
-      endDate = startDate;
+      setError("Invalid date range");
+    } else {
+      setError(null);
     }
     dispatch({
-      type: 'SET_FILTER_DATE_RANGE',
+      type: "SET_FILTER_DATE_RANGE",
       payload: { startDate, endDate },
     });
   };
 
-  const handleEndDateChange = (
-    e: React.ChangeEvent<HTMLInputElement>,
-  ) => {
+  const handleEndDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const endDate = e.target.value ? new Date(e.target.value) : undefined;
-    let startDate = filter.startDate;
+    const startDate = filter.startDate;
     if (startDate && endDate && endDate < startDate) {
-      startDate = endDate;
+      setError("Invalid date range");
+    } else {
+      setError(null);
     }
     dispatch({
-      type: 'SET_FILTER_DATE_RANGE',
+      type: "SET_FILTER_DATE_RANGE",
       payload: { startDate, endDate },
     });
   };
 
   return (
     <div className={styles.filters}>
-      <select
-        value={filter.categoryId ?? ''}
-        onChange={handleCategoryChange}
-      >
+      <select value={filter.categoryId ?? ""} onChange={handleCategoryChange}>
         <option value="">All</option>
         {CATEGORIES.map((cat) => (
           <option key={cat.id} value={cat.id}>
@@ -73,6 +68,11 @@ const ExpenseFilters: React.FC = () => {
         value={formatInputDate(filter.endDate)}
         onChange={handleEndDateChange}
       />
+      {error && (
+        <span role="alert" className={styles.error}>
+          {error}
+        </span>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add validation for invalid date ranges
- show filter error feedback
- add integration tests covering add, filter and error flows

## Testing
- `CI=true npm test -- --silent`

------
https://chatgpt.com/codex/tasks/task_e_6849e6488430832db8b71e7f8804abab